### PR TITLE
Ss6 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.1 || ^5.0"
+        "silverstripe/framework": "^4.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Forms/ColorPickerField.php
+++ b/src/Forms/ColorPickerField.php
@@ -30,4 +30,12 @@ class ColorPickerField extends SingleSelectField
             return $color['CSSClass'];
         }, $this->getSource()));
     }
+
+    /**
+     * Return the value of this field (for SilverStripe 6 compatibility)
+     */
+    public function Value()
+    {
+        return $this->value;
+    }
 }


### PR DESCRIPTION
Simple change to allow for SS6.  Tested on our site that uses it with this in composer:

` "silverstripe/recipe-cms": "~6.0.0@stable",`