### PR TITLE
MNT Use PHP 8 for Scrutinizer and Travis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,8 +3,25 @@ inherit: true
 build:
   nodes:
     analysis:
+      environment:
+        php:
+          version: 7.3
+
+      dependencies:
+        before:
+          - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+          - php composer-setup.php --2 --filename=composer
+          - rm composer-setup.php
+          - export PATH="$PWD:$PATH"
+          - composer config --no-plugins allow-plugins.composer/installers true
+          - composer config --no-plugins allow-plugins.silverstripe/vendor-plugin true
+
       tests:
-        override: [php-scrutinizer-run]
+        override:
+          - export PATH="$PWD:$PATH"
+          - composer config --no-plugins allow-plugins.composer/installers true
+          - composer config --no-plugins allow-plugins.silverstripe/vendor-plugin true
+          - php-scrutinizer-run
 
 checks:
   php:


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

Update Travis and Scrutinizer configs to run on PHP 8.x

## Issues

https://github.com/silverstripe/silverstripe-colorpicker/issues/30

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
